### PR TITLE
command to clear list and ability to reference by role ID

### DIFF
--- a/roles/index.py
+++ b/roles/index.py
@@ -96,7 +96,7 @@ class Roles(commands.Cog):
 
         targetRole = None
         for role in ctx.guild.roles:
-            if role.name == role_name and role.id in gameIds:
+            if not role.permissions.manage_guild and role.name == role_name and role.id in gameIds:
                 targetRole = role
 
         if targetRole is None:

--- a/roles/index.py
+++ b/roles/index.py
@@ -161,7 +161,7 @@ class Roles(commands.Cog):
 
         targetRole = None
         for role in ctx.guild.roles:
-            if role.name == role_name or role.id == role_name:
+            if not role.permissions.manage_guild and role.name == role_name or role.id == role_name:
                 targetRole = role
 
         if targetRole is None:

--- a/roles/index.py
+++ b/roles/index.py
@@ -186,8 +186,9 @@ class Roles(commands.Cog):
 
         targetRole = None
         for role in ctx.guild.roles:
-            if role.name == role_name or role.id == role_name:
-                targetRole = role
+            if role.id in departmentIds:
+                if role.name == role_name or role.id == role_name:
+                    targetRole = role
 
         if targetRole is None:
             await ctx.send(content="Role not found: {}".format(role_name))
@@ -204,7 +205,7 @@ class Roles(commands.Cog):
     @checks.mod_or_permissions(manage_guild=True)
     @department.command(name="reset")
     @commands.guild_only()
-    async def _remove_department(self, ctx: commands.Context, *, role_name: str):
+    async def _reset_departments(self, ctx: commands.Context, *, role_name: str):
         """Empties department list."""
 
         await self.config.guild(ctx.guild).departments.set([])

--- a/roles/index.py
+++ b/roles/index.py
@@ -161,7 +161,7 @@ class Roles(commands.Cog):
 
         targetRole = None
         for role in ctx.guild.roles:
-            if role.name == role_name:
+            if role.name == role_name or role.id == role_name:
                 targetRole = role
 
         if targetRole is None:
@@ -186,7 +186,7 @@ class Roles(commands.Cog):
 
         targetRole = None
         for role in ctx.guild.roles:
-            if role.name == role_name:
+            if role.name == role_name or role.id == role_name:
                 targetRole = role
 
         if targetRole is None:
@@ -201,6 +201,14 @@ class Roles(commands.Cog):
         await self.config.guild(ctx.guild).departments.set(departmentIds)
         await ctx.send(content="Department removed: {}".format(targetRole))
 
+    @checks.mod_or_permissions(manage_guild=True)
+    @department.command(name="reset")
+    @commands.guild_only()
+    async def _remove_department(self, ctx: commands.Context, *, role_name: str):
+        """Empties department list."""
+
+        await self.config.guild(ctx.guild).departments.set([])
+
     @department.command(name="select")
     @commands.guild_only()
     async def _select_department(self, ctx: commands.Context, *, role_name: str):
@@ -211,10 +219,11 @@ class Roles(commands.Cog):
         departmentsToBeRemoved = []
         targetRole = None
         for role in ctx.guild.roles:
-            if role.id in departmentIds and role in ctx.message.author.roles:
-                departmentsToBeRemoved.append(role)
-            if role.name == role_name:
-                targetRole = role
+            if role.id in departmentIds:
+                if role in ctx.message.author.roles:
+                    departmentsToBeRemoved.append(role)
+                if role.name == role_name or role.id == role_name:
+                    targetRole = role
 
         if targetRole is None:
             await ctx.send(content="Role not found: {}".format(role_name))


### PR DESCRIPTION
This commit provides a number of small updates to the departments command to help with ease of use and disambiguation when two roles have the same name